### PR TITLE
Properly referencing wp_load.php

### DIFF
--- a/sharify-style.php
+++ b/sharify-style.php
@@ -1,5 +1,5 @@
 <?php
- $absolute_path = explode('wp-content', $_SERVER['SCRIPT_FILENAME']);
+ $absolute_path = get_home_path();
  $wp_load = $absolute_path[0] . 'wp-load.php';
  require_once($wp_load);
 


### PR DESCRIPTION
Adding the function call to use instead of exploding the url as it doesn't always work.

I'm using [Bedrock](https://roots.io/bedrock/) and Composer to manage my dependencies and it puts Wordpress in a different folder to what you would normally expect, so it breaks for me.

This function references the proper location for `wp_load.php`